### PR TITLE
Added ability to scan wikipedia pages for track names and times

### DIFF
--- a/split.py
+++ b/split.py
@@ -52,55 +52,63 @@ def timeToSeconds(time):
 
 
 def findTrackSection(lines):
-	while lines:
-		line = lines[0]
-		if 'Track listing[edit]' in line:
-			return True
-		else:
-			del lines[0]
-	return False
+  while lines:
+    line = lines[0]
+    if 'Track listing[edit]' in line:
+      return True
+    else:
+      del lines[0]
+  return False
 
 
 def findTrackTable(lines):
-	while lines:
-		line = lines[0]
-		if 'No.' in line:
-			del lines[0]
-			return True
-		else:
-			del lines[0]
-	return False
+  while lines:
+    line = lines[0]
+    if 'No.' in line:
+      del lines[0]
+      return True
+    else:
+      del lines[0]
+  return False
 
 
 def writeWikiToTracks(track_times, track_titles):
-	track_file = open('tracks.txt', 'w')
-	text = ""
-	for num in range(len(track_times)):
-		text += (track_times[num] + ' - ' + track_titles[num] + '\n')
-	track_file.seek(0)
-	track_file.write(text)
-	track_file.truncate()
-	track_file.close()
+  track_file = open('tracks.txt', 'w')
+  text = ""
+  for num in range(len(track_times)):
+    text += (track_times[num] + ' - ' + track_titles[num] + '\n')
+    track_file.seek(0)
+    track_file.write(text)
+    track_file.truncate()
+    track_file.close()
 
 
 def wikiLookup(url):
-	os.system('lynx -dump -nolist \''+ url + '\' > ./.tmp.txt')
-	wiki_file = open('.tmp.txt')
-	lines = wiki_file.readlines()
-	track_times = []
-	track_titles = []
-	if findTrackSection(lines) and findTrackTable(lines):
-		while lines:
-			line = lines[0]
-			read_title = re.search('\"[^\"]*\"', line)
-			read_time = re.search('\d*:\d\d', line)
-			if not read_time:
-				break
-			track_times.append(read_time.group(0))
-			track_titles.append(read_title.group(0))
-			del lines[0]
-	writeWikiToTracks(track_times, track_titles)
-	os.remove('./.tmp.txt')
+  try:
+    os.system('lynx -dump -nolist \''+ url + '\' > ./.tmp.txt')
+  except OSError:
+    print("OSError occured, check if you have lynx browser properly installed.")
+    return
+
+  wiki_file = open('.tmp.txt')
+  lines = wiki_file.readlines()
+  track_times = []
+  track_titles = []
+  if findTrackSection(lines) and findTrackTable(lines):
+    while lines:
+      line = lines[0]
+      read_title = re.search('\"[^\"]*\"', line)
+      read_time = re.search('\d*:\d\d', line)
+      if not read_time:
+        break
+      track_times.append(read_time.group(0))
+      track_titles.append(read_title.group(0))
+      del lines[0]
+  writeWikiToTracks(track_times, track_titles)
+  os.remove('./.tmp.txt')
+  else:
+    print("Wikipedia page was not read correctly, check if page has track listing section")
+    print("Defaulting to current tracks.txt file")
 
 
 if __name__ == "__main__":

--- a/split.py
+++ b/split.py
@@ -75,7 +75,7 @@ def updateTimeChange(time_elapsed, track_time):
 
   str_m = ""
   str_s = ""
-  #1->01
+  #1 -> 01 
   if elapsed_m < 10:
     str_m = "0" + str(elapsed_m)
   else:
@@ -105,11 +105,6 @@ def writeWikiToTracks(track_times, track_titles):
 
 def extract_from_unicode(title):
   u = title.encode('utf-8', 'ignore')
-  return re.findall('"([^"]*)"', u[0])
-
-
-def extract_from_unicode(title):
-  u = title.encode('utf-8', 'ignore')
   return re.findall('"([^"]*)"', u)[0]
 
 
@@ -125,6 +120,7 @@ def extract_title(track_line):
   else:
     title = extract_from_unicode(track_line.contents[3].contents[0])
   return title
+
 
 def wikiLookup(url):
   page_html = urllib2.urlopen(url).read()
@@ -171,6 +167,7 @@ if __name__ == "__main__":
     FOLDER = args.folder
 
   if WIKI_URL:
+    print("Parsing " + WIKI_URL)
     wikiLookup(WIKI_URL)
 
   #create destination folder

--- a/split.py
+++ b/split.py
@@ -52,46 +52,50 @@ def timeToSeconds(time):
   return seconds
 
 
-def updateTimeChange(tt, track_time):
-  H = int(tt[:1])
-  M = int(tt[2:4])
-  S = int(tt[5:7])
+def updateTimeChange(time_elapsed, track_time):
+  elapsed_h = int(time_elapsed[:1])
+  elapsed_m = int(time_elapsed[2:4])
+  elapsed_s = int(time_elapsed[5:7])
   # 1:23 -> 01:23
   if(len(track_time) == 4):
    track_time = "0" + track_time
-  TM = int(track_time[:2])
-  TS = int(track_time[3:])
-  NM = M + TM
-  NS = S + TS
+  #get track length
+  track_m = int(track_time[:2])
+  track_s = int(track_time[3:])
+  #add track length to elapsed time
+  elapsed_m = elapsed_m + track_m
+  elapsed_s = elapsed_s + track_s
 
-  if NM >= 60:
-    NM -= 60
-    H += 1
-  elif NS >= 60:
-    NS -= 60
-    NM +=1
-  SM = ""
-  SS = ""
-  if NM < 10:
-    SM = "0" + str(NM)
+  if elapsed_m >= 60:
+    elapsed_m -= 60
+    elapsed_h += 1
+  elif elapsed_s >= 60:
+    elapsed_s -= 60
+    elapsed_m +=1
+
+  str_m = ""
+  str_s = ""
+  #1->01
+  if elapsed_m < 10:
+    str_m = "0" + str(elapsed_m)
   else:
-    SM = str(NM)
+    str_m = str(elapsed_m)
 
-  if NS < 10:
-    SS = "0" + str(NS)
+  if elapsed_s < 10:
+    str_s = "0" + str(elapsed_s)
   else:
-    SS = str(NS)
+    str_s = str(elapsed_s)
 
-  return "" + str(H) + ':' + SM + ':' + SS 
+  return str(elapsed_h) + ':' + str_m + ':' + str_s 
   
 
 def writeWikiToTracks(track_times, track_titles):
   track_file = open('tracks.txt', 'w')
-  tt = "0:00:00"
+  time_elapsed = "0:00:00"
   text = ""
   for num in range(len(track_times)):
-    text += (tt + ' - ' + str(track_titles[num]) + '\n')
-    tt = updateTimeChange(tt, track_times[num])
+    text += (time_elapsed + ' - ' + str(track_titles[num]) + '\n')
+    time_elapsed = updateTimeChange(time_elapsed, track_times[num])
 
   track_file.seek(0)
   track_file.write(text)

--- a/split.py
+++ b/split.py
@@ -50,10 +50,63 @@ def timeToSeconds(time):
   return seconds
 
 
+
+def findTrackSection(lines):
+	while lines:
+		line = lines[0]
+		if 'Track listing[edit]' in line:
+			return True
+		else:
+			del lines[0]
+	return False
+
+
+def findTrackTable(lines):
+	while lines:
+		line = lines[0]
+		if 'No.' in line:
+			del lines[0]
+			return True
+		else:
+			del lines[0]
+	return False
+
+
+def writeWikiToTracks(track_times, track_titles):
+	track_file = open('tracks.txt', 'w')
+	text = ""
+	for num in range(len(track_times)):
+		text += (track_times[num] + ' - ' + track_titles[num] + '\n')
+	track_file.seek(0)
+	track_file.write(text)
+	track_file.truncate()
+	track_file.close()
+
+
+def wikiLookup(url):
+	os.system('lynx -dump -nolist \''+ url + '\' > ./.tmp.txt')
+	wiki_file = open('.tmp.txt')
+	lines = wiki_file.readlines()
+	track_times = []
+	track_titles = []
+	if findTrackSection(lines) and findTrackTable(lines):
+		while lines:
+			line = lines[0]
+			read_title = re.search('\"[^\"]*\"', line)
+			read_time = re.search('\d*:\d\d', line)
+			if not read_time:
+				break
+			track_times.append(read_time.group(0))
+			track_titles.append(read_title.group(0))
+			del lines[0]
+	writeWikiToTracks(track_times, track_titles)
+	os.remove('./.tmp.txt')
+
+
 if __name__ == "__main__":
   print("Starting")
 
-  
+
   #arg parsing
   parser = argparse.ArgumentParser(description='Split a single-file mp3 Album into its tracks.')
   group = parser.add_mutually_exclusive_group(required=True)
@@ -63,17 +116,23 @@ if __name__ == "__main__":
   parser.add_argument("-A",  "--album", help="Specify the album that the mp3s will be ID3-tagged with. Default: no tag", default=None)
   parser.add_argument("-t", "--tracks", help="Specify the tracks file. Default: tracks.txt", default="tracks.txt")
   parser.add_argument("-f", "--folder", help="Specify the folder the mp3s will be put in. Default: splits/", default="splits")
+  parser.add_argument("-u", "--wikiurl", help="URL of wikipedia page with album track list table.", default=None)
+
   args = parser.parse_args()
   TRACKS_FILE =  args.tracks
   FILENAME = args.mp3
   YT_URL = args.yt
   ALBUM = args.album
   ARTIST = args.artist
+  WIKI_URL = args.wikiurl
 
   if ALBUM and ARTIST and args.folder == "splits":
     FOLDER = ARTIST + " - " + ALBUM
   else:
     FOLDER = args.folder
+
+  if WIKI_URL:
+    wikiLookup(WIKI_URL)
 
   #create destination folder
   if not os.path.exists(FOLDER):


### PR DESCRIPTION
Hi crisbal,

Added this small feature as a way to add a little automation to a kinda tedious task. Since the youtube comments lack an official format they are a little harder to work with. Wikipedia (for the most part) has a consistent format for their wikipedia pages on track listings. 

The commits just add a few methods for scanning those wikipedia pages. I also used the lynx browser to get the webpage content mostly out of ease of use. If you think it's worth it doing the same purely with python is probably possible and I can rework it for that. My python isn't the best so feel free to rewrite it as you see fit if I did something inefficiently or confusingly. Also first pull request. 

By the way, great job on the album splitting! I wish I would have thought of this earlier. You should really think about maybe adding this somehow to the main youtube-dl project. Anyways look over it and get back to me if I need to change anything. Have a good weekend!

Best Regards, 
Inondle