### PR TITLE
Adds support for threaded execution, change download file format to .wav

### DIFF
--- a/WikiParser.py
+++ b/WikiParser.py
@@ -33,21 +33,14 @@ def lookup(url):
     return True
 
 
-def extract_from_unicode(title):
-    return re.findall('"([^"]*)"', title)[0]
-
-
-def extract_linked_title(linked_title):
-    l = linked_title.contents[3].contents[1].contents[0]
-    return l
-
-
 def extract_title(track_line):
-    if(len(track_line.contents[3].contents) > 1):
-        # title is linked...
-        title = extract_linked_title(track_line)
+    title = None
+    title_row = track_line.contents[3]
+    if len(title_row.contents) > 1 and not title_row('span'):
+        # Get title from a link
+        title = title_row.contents[1].contents[0]
     else:
-        title = extract_from_unicode(track_line.contents[3].contents[0])
+        title = title_row.contents[0]
     return title
 
 


### PR DESCRIPTION
This commit uses the `threading` module and `queue` module to implement a pretty simple threading option. If you specify `-th` then it triggers threading, otherwise it is non-threaded. `--num-threads` allows you to specify how many threads you want to use, if user specifies a number <= 0 then it just defaults to non-threaded execution. The threading adds a significant performance increase. In my limited testing I've found that 3 threads (default) cuts the time roughly in half. From ~450 to ~210 seconds in my example. 
 

I also looked at the source code for `audioSegment.from_file` and found that at [line 365](https://github.com/jiaaro/pydub/blob/master/pydub/audio_segment.py#L365) in the AudioSegment code that if it is given a wav file then it skips a bunch of other commands (and I think some sort of [decoding](https://github.com/jiaaro/pydub/blob/master/pydub/audio_segment.py#L406)?). Since youtube-dl can encode the audio as a wav file I changed it to encode the audio to that instead. In my limited testing it seems this change shaves off around 4 seconds. 


There are also a few small improvements to the wikiparser file. 