### PR TITLE
Separate split_song method from split.py

### DIFF
--- a/split.py
+++ b/split.py
@@ -7,11 +7,10 @@ from threading import Thread
 from uuid import uuid4
 
 from urllib.parse import urlparse, parse_qs
-from mutagen.easyid3 import EasyID3
 from pydub import AudioSegment
 from youtube_dl import YoutubeDL
 
-from utils import (time_to_seconds, track_parser, update_time_change)
+from utils import (split_song, time_to_seconds, track_parser, update_time_change)
 
 
 metadata_providers = []
@@ -32,29 +31,10 @@ class MyLogger(object):
         print(msg)
 
 
-def thread_func(album, tracks_start, queue, FOLDER):
+def thread_func(album, tracks_start, queue, FOLDER, ARTIST, ALBUM):
     while not queue.empty():
         song_tuple = queue.get()
-        split_song(album, tracks_start, song_tuple[0], song_tuple[1], FOLDER)
-
-
-def split_song(album, tracks_start, index, track, FOLDER):
-    print("\t{}) {}".format(str(index+1), track))
-    start = tracks_start[index]
-    end = tracks_start[index+1]
-    duration = end-start
-    track_path = '{}/{:02d} - {}.mp3'.format(FOLDER, index+1, track)
-    album[start:][:duration].export(track_path, format="mp3")
-
-    print("\t\tTagging")
-    song = EasyID3(track_path)
-    if ARTIST:
-            song['artist'] = ARTIST
-    if ALBUM:
-            song['album'] = ALBUM
-    song['title'] = track
-    song['tracknumber'] = str(index+1)
-    song.save()
+        split_song(album, tracks_start, song_tuple[0], song_tuple[1], FOLDER, ARTIST, ALBUM)
 
 
 def my_hook(d):

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,3 +1,4 @@
+from .split_song import split_song
 from .time_to_seconds import time_to_seconds
 from .track_parser import track_parser
 from .update_time_change import update_time_change

--- a/utils/split_song.py
+++ b/utils/split_song.py
@@ -1,0 +1,20 @@
+from mutagen.easyid3 import EasyID3
+
+
+def split_song(album, tracks_start, index, track, folder='.', artist='', album_title=''):
+    print("\t{}) {}".format(str(index+1), track))
+    start = tracks_start[index]
+    end = tracks_start[index+1]
+    duration = end-start
+    track_path = '{}/{:02d} - {}.mp3'.format(folder, index+1, track)
+    album[start:][:duration].export(track_path, format="mp3")
+
+    print("\t\tTagging")
+    song = EasyID3(track_path)
+    if artist:
+            song['artist'] = artist
+    if album_title:
+            song['album'] = album_title
+    song['title'] = track
+    song['tracknumber'] = str(index+1)
+    song.save()


### PR DESCRIPTION
Made `split_song` method independent from the `split.py` and placed it in the `utils` folder

Work in progress https://github.com/crisbal/Album-Splitter/issues/17