### PR TITLE
Update tag_data to add song title & track number to ID3 tags

### DIFF
--- a/album_splitter/__main__.py
+++ b/album_splitter/__main__.py
@@ -1,8 +1,6 @@
 import argparse
 from urllib.parse import parse_qs, urlparse
-from uuid import uuid4
 from pathlib import Path
-from collections import namedtuple
 import datetime
 
 from .parse_tracks import parse_tracks
@@ -172,7 +170,11 @@ if __name__ == "__main__":
     print("Splitting into files... (this could take a while)")
     output_files = split_file(input_file, tracks, outfolder, output_format=str(input_file).split(".")[-1])
     print("Tagging files, almost done...")
-    for file in output_files:
+    for index, file in enumerate(output_files):
+        track = tracks[index]
+        tag_data.update({
+            "title": str(track.title),
+            "tracknumber": index + 1
+        })
         tag_file(file, tag_data)
     print("Done!")
-


### PR DESCRIPTION
When splitting an album file the resulting song files
retain the same title as the original full album file.
e.g. if you had a full album file called "Pink Floyd - The Wall
(full).mp3", every track extracted would have the track title
"Pink Floyd - The Wall (full).mp3".

In addition, the track number is not included in tag_data, This results
in needing to manually update the ID3 title & track number tags with
only the track length (or listening to the track) as a clue to which
track is which.

Adding track title and track number to tag_data to fix this.

Also removed unused uuid & namedtuple imports.