### PR TITLE
Fixed cover art being dropped on file split

### DIFF
--- a/album_splitter/split_file.py
+++ b/album_splitter/split_file.py
@@ -16,18 +16,15 @@ def split_file(input_file: Path, tracks: List[Track], destination: Path, output_
     for i, track in enumerate(tracks):
         start_timestamp = track.start_timestamp
         end_timestamp = file_duration if i == len(tracks) - 1 else tracks[i + 1].start_timestamp
-        outputs[
-            destination / (f"{track.title}.{output_format}")
-        ] = f"-vn -c copy -ss {start_timestamp} -to {end_timestamp}"
-    split_command = ffmpy.FFmpeg(
-        inputs={
-            str(input_file): "-y -hide_banner -loglevel error -stats"}, 
-            outputs={ str(path): v for path, v in outputs.items()
-        }
-    )
-    try:
-        split_command.run()
-    except:
-        raise Exception("Something went wrong with the splitting procedure. See the error above.") from None
+        output_file = destination / (f"{track.title}.{output_format}")
+            
+        split_command = ffmpy.FFmpeg(
+            inputs={str(input_file): f"-y -hide_banner -loglevel error -stats -ss {start_timestamp} -t {end_timestamp}"},
+            outputs={ str(output_file): "-c copy" }
+        )
+        try:
+            split_command.run()
+        except:
+            raise Exception("Something went wrong with the splitting procedure. See the error above.") from None
 
     return list(outputs.keys())


### PR DESCRIPTION
Noticed that even though my source file had an embedded cover art, it was being lost during the split. This fix involves:
- Removing the `-an` flag from the split command (as the cover art is embedded in a video stream, we need the video now)
- Moving the `-ss -t` flags before the `-i` (See https://superuser.com/questions/758338/keep-album-art-with-ffmpeg-while-cutting-a-mp3-file)

Because of how the `ffmpy` library syntax works, that wasn't possible by keeping a single source file, so I had to split the split (heh) process into one ffmpeg command for each track - it's a tad bit slower, but can't think of another way to do this.

