### PR TITLE
Add automatic tracks/metadata extraction and playlist handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ After the first time:
 ## Quick guide (from a YouTube video)
 
 + Copy the YouTube URL of the album you want to download and split
-+ Find in the YouTube comments the tracklist with start-time and title
++ Find in the YouTube comments the tracklist with start-time and title (with the --extract-track argument, this is done automatically)
 + Create a copy of the `tracks.txt.example`, rename it as `tracks.txt`
 + Open `tracks.txt`
 + Copy the tracklist in the file, adjusting for the supported formats
@@ -81,6 +81,7 @@ After the first time:
 + Wait for the Download and for the conversion
 + Wait for the splitting process to complete
 + You will find your tracks in the `./splits` folder
++ It also works on playlists, downloading and splitting them one by one
 
 ## Output Format
 

--- a/album_splitter/__main__.py
+++ b/album_splitter/__main__.py
@@ -1,18 +1,17 @@
 import argparse
 import datetime
-import re
 import sys
-import json
+import urllib.request
 from pathlib import Path
 from urllib.parse import parse_qs, urlparse
 from typing import List, Dict, Any, Optional
 
 from yt_dlp import YoutubeDL
 
-from .parse_tracks import parse_tracks, parse_time_string, Track
+from .parse_tracks import parse_tracks, infer_tracks_from_text, timestamp_regex, Track
 from .split_file import split_file
 from .tag_file import tag_file
-from .utils.secure_filename import secure_filename
+from .utils.secure_filename import secure_filename_simple
 from .utils.ytdl_interface import ydl_opts
 
 
@@ -125,84 +124,47 @@ class AlbumSplitterError(Exception):
     pass
 
 
-timestamp_regex = re.compile(r"((?:\d+:)?[0-5]?\d:[0-5]?\d)")
-
-def infer_tracks_from_text(text: str) -> List[Track]:
-    """
-    Try to infer a tracklist from a non-formatted text.
-    It assumes the timestamps are in [hh]:mm:ss format and come before the track name.
-    The track name is everything after the timestamp until the next timestamp, cleaned up.
-
-    :param text: The text to parse.
-
-    :return: A list of tracks.
-    """
-
-    # timestamps
-    timestamps = timestamp_regex.findall(text)
-
-    # track names
-    timestamps_end = [m.end() for m in timestamp_regex.finditer(text)]
-    track_names = [re.match(".*", text[end:]).group(0) for end in timestamps_end]
-
-    # clean up track names
-    trailing_chars_regex = re.compile(r"^[\s|:\-_~)\]}>]+")
-    leading_chars_regex = re.compile(r"[\s|:_(\[{<]+$")
-
-    track_names = [trailing_chars_regex.sub("", track_name) for track_name in track_names]
-    track_names = [leading_chars_regex.sub("", track_name) for track_name in track_names]
-
-    # create tracks
-    tracks = [
-        Track(track_name, parse_time_string(timestamp))
-        for track_name, timestamp in zip(track_names, timestamps)
-    ]
-
-    return tracks
-
-
 def extract_tracks_from_youtube(youtube_url: str) -> List[Track]:
     extractor_args = {
         "youtube": {
-            "max_comments": ["10", "all", "0", "0"],    # up to 10 comments with no replies
-            "comment_sort": "top"                       # sort by top comments
+            "comment_sort": ["top"],                     # sort by top comments
+            "max_comments": ["all", "all", "0", "0"],    # up to 10 comments with no replies
         }
     }
 
-    # TODO: reduce payload size. We only need the chapters, description, and comments.
     with YoutubeDL({**ydl_opts, "getcomments": True, "extractor_args": extractor_args}) as ydl:
         info: Dict[str, Any] = ydl.extract_info(youtube_url, download = False)
 
-        tracklist = info.get("chapters")
-
-        # tracklist found in info, parse it
-        if tracklist is not None:
-            # TODO: remove "<Untitled chapter ...>" tracks ?
-            return [Track(track["title"], parse_time_string(track["start_time"])) for track in tracklist]
+        # NOTE: chapters are disabled as they are unreliable in numerous cases (number, names, etc.)
+        # tracklist = info.get("chapters")
 
         # tracklist not found in info, try to extract from description
         description = info.get("description")
-        # TODO: put a min threshold on the number of timestamps ?
-        if description is not None and 0 < len(timestamp_regex.findall(description)):
+        size_tracks_in_description = len(timestamp_regex.findall(description)) if description is not None else 0
+        if 2 < size_tracks_in_description:
             return infer_tracks_from_text(description)
 
         # tracklist not found in description, try to extract from comments (max 10 comments)
-        comments = info.get("comments")
-        if comments is not None and 0 < len(comments):
+        comment_entries = info.get("comments")
+        if comment_entries is not None and 0 < len(comment_entries):
+            comments = [entry["text"] for entry in comment_entries[:10]]
+
             # we look for the comment with the most mm:ss timestamps
             timestamp_regex_matches = [timestamp_regex.findall(comment) for comment in comments]
             timestamp_regex_matches_len = [len(m) for m in timestamp_regex_matches]
             max_timestamp_regex_matches_len = max(timestamp_regex_matches_len)
 
-            # TODO: put a min threshold on the number of timestamps ?
-            if 0 < max_timestamp_regex_matches_len:
+            if 2 < max_timestamp_regex_matches_len:
                 max_timestamps_index = timestamp_regex_matches_len.index(max_timestamp_regex_matches_len)
                 max_timestamps_comment = comments[max_timestamps_index]
 
                 return infer_tracks_from_text(max_timestamps_comment)
 
         # tracklist not found in info, description, or comments, abort
-        raise AlbumSplitterError(f"Tracklist not found in {youtube_url}")
+        if info.get("title") is None:
+            raise AlbumSplitterError(f"Tracklist not found in {youtube_url}")
+        else:
+            raise AlbumSplitterError(f"Tracklist not found in {youtube_url} ({info['title']})")
 
 
 def main(argv: Optional[List[str]] = None):
@@ -210,7 +172,7 @@ def main(argv: Optional[List[str]] = None):
     args = parser.parse_args(argv)
 
     yt_video_id = None
-    yt_video_name = None
+    yt_thumbnails = []
 
     ydl_opts["postprocessors"][0]["preferredcodec"] = args.format
 
@@ -230,32 +192,32 @@ def main(argv: Optional[List[str]] = None):
             )
 
         if args.extract_metadata:
-            # TODO: reduce payload size. We only need the uploader, title, and upload date
             with YoutubeDL(ydl_opts) as ydl:
                 info: Dict[str, Any] = ydl.extract_info(args.youtube_url, download = False)
 
-                yt_video_name = info.get("title")  # or "fulltitle" ?
-                args.artist = args.artist or info.get("uploader")
-                args.album = args.album or info.get("title")
+                args.folder = info.get("title").strip()  # or "fulltitle" ?
+                args.artist = args.artist or info.get("uploader").strip()
+                args.album = args.album or info.get("title").strip()
                 args.year = args.year or info.get("upload_date", "0000")[:4]
 
-                # TODO: extract 'thumbnail' or biggest 'thumbnails' for image ?
-        else:
-            yt_video_name = yt_video_id
-
+                # TODO: get thumbnail for all chapters (complicated without downloading the video
+                #       if chapters are not there)
+                # I think we can get the thumbnail for each chapter if chapters are there
+                if info.get("thumbnail"):
+                    yt_thumbnails = [info.get("thumbnail")]
 
     # infer default output folder
     if not args.folder:
         if args.album or args.artist:
             args.folder = args.album or args.artist
             if args.album and args.artist:
-                args.folder = secure_filename(f"{args.artist} - {args.album}")
+                args.folder = f"{args.artist} - {args.album}"
         else:
             if args.youtube_url:
-                assert yt_video_name
-                args.folder = "./splits/{}".format(secure_filename(yt_video_name))
+                assert yt_video_id
+                args.folder = "./splits/{}".format(yt_video_id)
             else:
-                args.folder = "./splits/{}".format(secure_filename(args.audio_file))
+                args.folder = "./splits/{}".format(args.audio_file)
 
     print("Reading tracks")
     if args.extract_track:
@@ -272,6 +234,12 @@ def main(argv: Optional[List[str]] = None):
         tracks = parse_tracks(tracks_content, duration=args.duration)
         if not len(tracks):
             raise AlbumSplitterError("No tracks could be read/parsed from the tracks file.")
+
+    # sort tracks by start timestamp (in case they are not already), as ffmpeg requires them to be
+    sorted_tracks = sorted(tracks, key = lambda t: t.start_timestamp)
+    if sorted_tracks != tracks:
+        print("Warning: Tracks were not in the right order. Check the source for mistakes.")
+    tracks = sorted_tracks
 
     # build the id3-tags
     tag_data = {}
@@ -310,9 +278,7 @@ def main(argv: Optional[List[str]] = None):
 
         # TODO: do the checks on the webm directly, then convert to format ? Would allow for multiple formats
         #       without having to download the video multiple times
-
-        # youtube videos are downloaded as webm, so it makes no sense to use them as wav (10x bigger)
-        input_file = Path(yt_video_id + f".{args.format}")
+        input_file = Path(f"{yt_video_id}.{args.format}")
         if not input_file.exists():
             print("Downloading video from YouTube")
             with YoutubeDL(ydl_opts) as ydl:
@@ -326,18 +292,40 @@ def main(argv: Optional[List[str]] = None):
         raise AlbumSplitterError(f"Can't find input file: {input_file}")
 
     # create output folder
-    outfolder = Path(args.folder)
+    outfolder = Path(secure_filename_simple(args.folder))
     outfolder.mkdir(parents=True, exist_ok=True)
+
+    # TODO: try to get refine the timestamps by detecting the silence between tracks (+- 3 seconds)
+    #       it would help correct inaccuracies and allow for a more precise split (0.5s off can be jarring)
 
     # do the work
     print("Splitting into files... (this could take a while)")
     output_files = split_file(
         input_file, tracks, outfolder, output_format=str(input_file).split(".")[-1]
     )
+
     print("Tagging files, almost done...")
+    # download thumbnails
+    yt_thumbnails_paths = [outfolder / f"thumbnail_{index}.jpg" for index, _ in enumerate(yt_thumbnails)]
+    for thumbnail_url, thumbnail_file in zip(yt_thumbnails, yt_thumbnails_paths):
+        if not thumbnail_file.exists():
+            urllib.request.urlretrieve(thumbnail_url, thumbnail_file)
+
+    # extend the thumbnails to the length of the tracks if needed
+    if len(yt_thumbnails_paths) == 1:
+        yt_thumbnails_paths *= len(tracks)
+
     for index, file in enumerate(output_files):
         track = tracks[index]
-        tag_data.update({"title": str(track.title), "tracknumber": index + 1})
+        tag_data.update({
+            "title": str(track.title),
+            "tracknumber": index + 1,
+            "totaltracks": len(tracks),
+        })
+
+        if index < len(yt_thumbnails_paths):
+            tag_data["artwork"] = yt_thumbnails_paths[index].read_bytes()
+
         tag_file(file, tag_data)
 
     print(f"Done! You can find your tracks in {outfolder}")
@@ -353,10 +341,8 @@ def playlist_dispatch():
     args = parser.parse_args()
 
     if args.youtube_url and args.extract_track:
-        # TODO: reduce payload size. We only need the urls, not the full info
-        with YoutubeDL({**ydl_opts, "compat_opts": ["no-youtube-unavailable-videos"]}) as ydl:
+        with YoutubeDL({**ydl_opts, "extract_flat": True, "compat_opts": ["no-youtube-unavailable-videos"]}) as ydl:
             info: Dict[str, Any] = ydl.extract_info(args.youtube_url, download = False)
-
             if info.get("_type") == "playlist":
                 entries = info.get("entries")
 
@@ -365,13 +351,13 @@ def playlist_dispatch():
 
                 print(f"Playlist detected, {len(entries)} entries found")
 
-                argv = sys.argv.copy()
+                argv = sys.argv[1:]
                 url_index = argv.index(args.youtube_url)
 
                 for entry in entries:
                     try:
                         # substitute the URL in the argv list with the current entry
-                        url = entry.get("webpage_url")
+                        url = entry.get("url")
                         argv[url_index] = url
 
                         main(argv)
@@ -383,9 +369,8 @@ def playlist_dispatch():
                 sys.exit(0)
 
 def main_entry():
-    playlist_dispatch()
-
     try:
+        playlist_dispatch()
         main()
     except AlbumSplitterError as e:
         print("Error:", e, file = sys.stderr)

--- a/album_splitter/__main__.py
+++ b/album_splitter/__main__.py
@@ -1,11 +1,15 @@
 import argparse
 import datetime
+import re
+import sys
+import json
 from pathlib import Path
 from urllib.parse import parse_qs, urlparse
+from typing import List, Dict, Any, Optional
 
 from yt_dlp import YoutubeDL
 
-from .parse_tracks import parse_tracks
+from .parse_tracks import parse_tracks, parse_time_string, Track
 from .split_file import split_file
 from .tag_file import tag_file
 from .utils.secure_filename import secure_filename
@@ -17,6 +21,8 @@ def get_parser():
         prog="album-splitter",
         description="Split a single-file mp3 Album into its tracks.",
     )
+
+    # TODO: add credentials ?
 
     input_group = parser.add_argument_group("Input")
     input_file_group = input_group.add_mutually_exclusive_group(required=True)
@@ -41,6 +47,14 @@ def get_parser():
         "--duration",
         action="store_true",
         help="Tracks file format is in duration mode, as opposed to timestamp mode. (default: %(default)s)",
+        default=False,
+    )
+    input_group.add_argument(
+        "-et",
+        "--extract-track",
+        action = "store_true",
+        help="Try to extract the tracklist from the description of the YouTube video. "
+             "If it fails, searches in the top comments.",
         default=False,
     )
 
@@ -70,6 +84,16 @@ def get_parser():
         help="Extra tags for the output. `key=value` format. (default: %(default)s)",
         action="append",
     )
+    tracks_metadata_group.add_argument(
+        "-em",
+        "--extract-metadata",
+        action = "store_true",
+        help="Extract metadata from the YouTube video. "
+             "Name will be the title of the video, artist will be the uploader, "
+             "album will be the title of the video, and year will be the upload date. "
+             "Any of these can be overridden with their respective flags.",
+        default=False,
+    )
 
     output_group = parser.add_argument_group("Output")
     output_group.add_argument(
@@ -79,6 +103,11 @@ def get_parser():
         metavar="FOLDER",
         dest="folder",
         default=None,
+    )
+    output_group.add_argument(
+        "--format",
+        help="Output file format to use. (default: %(default)s)",
+        default="wav",
     )
 
     other_group = parser.add_argument_group("Other")
@@ -92,11 +121,99 @@ def get_parser():
     return parser
 
 
-def main():
+class AlbumSplitterError(Exception):
+    pass
+
+
+timestamp_regex = re.compile(r"((?:\d+:)?[0-5]?\d:[0-5]?\d)")
+
+def infer_tracks_from_text(text: str) -> List[Track]:
+    """
+    Try to infer a tracklist from a non-formatted text.
+    It assumes the timestamps are in [hh]:mm:ss format and come before the track name.
+    The track name is everything after the timestamp until the next timestamp, cleaned up.
+
+    :param text: The text to parse.
+
+    :return: A list of tracks.
+    """
+
+    # timestamps
+    timestamps = timestamp_regex.findall(text)
+
+    # track names
+    timestamps_end = [m.end() for m in timestamp_regex.finditer(text)]
+    track_names = [re.match(".*", text[end:]).group(0) for end in timestamps_end]
+
+    # clean up track names
+    trailing_chars_regex = re.compile(r"^[\s|:\-_~)\]}>]+")
+    leading_chars_regex = re.compile(r"[\s|:_(\[{<]+$")
+
+    track_names = [trailing_chars_regex.sub("", track_name) for track_name in track_names]
+    track_names = [leading_chars_regex.sub("", track_name) for track_name in track_names]
+
+    # create tracks
+    tracks = [
+        Track(track_name, parse_time_string(timestamp))
+        for track_name, timestamp in zip(track_names, timestamps)
+    ]
+
+    return tracks
+
+
+def extract_tracks_from_youtube(youtube_url: str) -> List[Track]:
+    extractor_args = {
+        "youtube": {
+            "max_comments": ["10", "all", "0", "0"],    # up to 10 comments with no replies
+            "comment_sort": "top"                       # sort by top comments
+        }
+    }
+
+    # TODO: reduce payload size. We only need the chapters, description, and comments.
+    with YoutubeDL({**ydl_opts, "getcomments": True, "extractor_args": extractor_args}) as ydl:
+        info: Dict[str, Any] = ydl.extract_info(youtube_url, download = False)
+
+        tracklist = info.get("chapters")
+
+        # tracklist found in info, parse it
+        if tracklist is not None:
+            # TODO: remove "<Untitled chapter ...>" tracks ?
+            return [Track(track["title"], parse_time_string(track["start_time"])) for track in tracklist]
+
+        # tracklist not found in info, try to extract from description
+        description = info.get("description")
+        # TODO: put a min threshold on the number of timestamps ?
+        if description is not None and 0 < len(timestamp_regex.findall(description)):
+            return infer_tracks_from_text(description)
+
+        # tracklist not found in description, try to extract from comments (max 10 comments)
+        comments = info.get("comments")
+        if comments is not None and 0 < len(comments):
+            # we look for the comment with the most mm:ss timestamps
+            timestamp_regex_matches = [timestamp_regex.findall(comment) for comment in comments]
+            timestamp_regex_matches_len = [len(m) for m in timestamp_regex_matches]
+            max_timestamp_regex_matches_len = max(timestamp_regex_matches_len)
+
+            # TODO: put a min threshold on the number of timestamps ?
+            if 0 < max_timestamp_regex_matches_len:
+                max_timestamps_index = timestamp_regex_matches_len.index(max_timestamp_regex_matches_len)
+                max_timestamps_comment = comments[max_timestamps_index]
+
+                return infer_tracks_from_text(max_timestamps_comment)
+
+        # tracklist not found in info, description, or comments, abort
+        raise AlbumSplitterError(f"Tracklist not found in {youtube_url}")
+
+
+def main(argv: Optional[List[str]] = None):
     parser = get_parser()
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     yt_video_id = None
+    yt_video_name = None
+
+    ydl_opts["postprocessors"][0]["preferredcodec"] = args.format
+
     if args.youtube_url:
         url_data = urlparse(args.youtube_url)
         if url_data.scheme == "":
@@ -112,6 +229,21 @@ def main():
                 f"Unknown YouTube url {args.youtube_url}. (Supported youtube.com, youtu.be)"
             )
 
+        if args.extract_metadata:
+            # TODO: reduce payload size. We only need the uploader, title, and upload date
+            with YoutubeDL(ydl_opts) as ydl:
+                info: Dict[str, Any] = ydl.extract_info(args.youtube_url, download = False)
+
+                yt_video_name = info.get("title")  # or "fulltitle" ?
+                args.artist = args.artist or info.get("uploader")
+                args.album = args.album or info.get("title")
+                args.year = args.year or info.get("upload_date", "0000")[:4]
+
+                # TODO: extract 'thumbnail' or biggest 'thumbnails' for image ?
+        else:
+            yt_video_name = yt_video_id
+
+
     # infer default output folder
     if not args.folder:
         if args.album or args.artist:
@@ -120,21 +252,26 @@ def main():
                 args.folder = secure_filename(f"{args.artist} - {args.album}")
         else:
             if args.youtube_url:
-                assert yt_video_id
-                args.folder = "./splits/{}".format(secure_filename(yt_video_id))
+                assert yt_video_name
+                args.folder = "./splits/{}".format(secure_filename(yt_video_name))
             else:
                 args.folder = "./splits/{}".format(secure_filename(args.audio_file))
 
-    print("Reading tracks file")
-    tracks_file = Path(args.tracks)
-    if not tracks_file.exists():
-        print(f"Can't find tracks file: {tracks_file}")
-        exit(-1)
-    tracks_content = tracks_file.read_text(encoding="utf-8", errors="ignore")
-    tracks = parse_tracks(tracks_content, duration=args.duration)
-    if not len(tracks):
-        print("No tracks could be read/parsed from the tracks file.")
-        exit(-1)
+    print("Reading tracks")
+    if args.extract_track:
+        if not args.youtube_url:
+            raise ValueError("Extracting tracks is only supported for YouTube videos.")
+
+        tracks = extract_tracks_from_youtube(args.youtube_url)
+    else:
+        tracks_file = Path(args.tracks)
+        if not tracks_file.exists():
+            raise AlbumSplitterError(f"Can't find tracks file: {tracks_file}")
+
+        tracks_content = tracks_file.read_text(encoding="utf-8", errors="ignore")
+        tracks = parse_tracks(tracks_content, duration=args.duration)
+        if not len(tracks):
+            raise AlbumSplitterError("No tracks could be read/parsed from the tracks file.")
 
     # build the id3-tags
     tag_data = {}
@@ -145,6 +282,7 @@ def main():
             "year": args.year,
         }
     )
+
     for tag_data_line in args.extra_metadata or []:
         k, v = tag_data_line.split("=")
         tag_data[k] = v.replace('"', "").replace("'", "")
@@ -153,31 +291,39 @@ def main():
         for track in tracks:
             fmt_timestamp = datetime.timedelta(seconds=track.start_timestamp)
             print(f"{track.title} - {fmt_timestamp}")
+
         for k, v in tag_data.items():
             print(f"{k} - {v}")
-        exit()
+
+        return
     else:
         print("Found the following tracks: ")
         for track in tracks:
             fmt_timestamp = datetime.timedelta(seconds=track.start_timestamp)
             print(f"\t{track.title} - {fmt_timestamp}")
+
     input_file = None
     if args.audio_file:
         input_file = Path(args.audio_file)
     elif args.youtube_url:
         assert yt_video_id
-        input_file = Path(yt_video_id + ".wav")
+
+        # TODO: do the checks on the webm directly, then convert to format ? Would allow for multiple formats
+        #       without having to download the video multiple times
+
+        # youtube videos are downloaded as webm, so it makes no sense to use them as wav (10x bigger)
+        input_file = Path(yt_video_id + f".{args.format}")
         if not input_file.exists():
             print("Downloading video from YouTube")
             with YoutubeDL(ydl_opts) as ydl:
                 ydl.download([args.youtube_url])
+
             print("\nConversion complete")
         else:
             print("Found matching file locally, no need to redownload from YouTube")
 
     if not input_file or not input_file.exists():
-        print(f"Can't find input file: {input_file}")
-        exit(-1)
+        raise AlbumSplitterError(f"Can't find input file: {input_file}")
 
     # create output folder
     outfolder = Path(args.folder)
@@ -193,8 +339,58 @@ def main():
         track = tracks[index]
         tag_data.update({"title": str(track.title), "tracknumber": index + 1})
         tag_file(file, tag_data)
+
     print(f"Done! You can find your tracks in {outfolder}")
 
 
+def playlist_dispatch():
+    """
+    Detect if the URL is a playlist, and if we have tracklist extraction enabled.
+    If so, this will call main() for each video in the playlist, extracting the tracks for each.
+    """
+
+    parser = get_parser()
+    args = parser.parse_args()
+
+    if args.youtube_url and args.extract_track:
+        # TODO: reduce payload size. We only need the urls, not the full info
+        with YoutubeDL({**ydl_opts, "compat_opts": ["no-youtube-unavailable-videos"]}) as ydl:
+            info: Dict[str, Any] = ydl.extract_info(args.youtube_url, download = False)
+
+            if info.get("_type") == "playlist":
+                entries = info.get("entries")
+
+                if not entries:
+                    raise AlbumSplitterError("No entry found in playlist")
+
+                print(f"Playlist detected, {len(entries)} entries found")
+
+                argv = sys.argv.copy()
+                url_index = argv.index(args.youtube_url)
+
+                for entry in entries:
+                    try:
+                        # substitute the URL in the argv list with the current entry
+                        url = entry.get("webpage_url")
+                        argv[url_index] = url
+
+                        main(argv)
+                    except AlbumSplitterError as e:
+                        print("Error:", e, file = sys.stderr)
+
+                    print("")
+
+                sys.exit(0)
+
+def main_entry():
+    playlist_dispatch()
+
+    try:
+        main()
+    except AlbumSplitterError as e:
+        print("Error:", e, file = sys.stderr)
+        sys.exit(-1)
+
+
 if __name__ == "__main__":
-    main()
+    main_entry()

--- a/album_splitter/parse_tracks.py
+++ b/album_splitter/parse_tracks.py
@@ -3,6 +3,8 @@ from collections import namedtuple
 
 import typing
 
+from .utils.secure_filename import secure_filename_simple
+
 Track = namedtuple("Track", ["title", "start_timestamp"])
 
 
@@ -30,7 +32,7 @@ def parse_tracks(tracks_content: str, duration: bool = False) -> typing.List[Tra
         track_time_seconds = parse_time_string(track_time)
         if not duration:
             current_time = track_time_seconds
-        tracks.append(Track(title=title, start_timestamp=current_time))
+        tracks.append(Track(title=secure_filename_simple(title), start_timestamp=current_time))
         if duration:
             current_time += track_time_seconds
     return tracks
@@ -56,3 +58,77 @@ def parse_line(line: str) -> typing.Tuple[str, str]:
         )
     title = title.strip(" -|")
     return timestamp, title
+
+
+timestamp_regex = re.compile(r"((?:\d+:)?[0-5]?\d:[0-5]?\d)")
+timestamp_regex_text = re.compile(r"^(.*?)((?:\d+:)?[0-5]?\d:[0-5]?\d)(.*)$")
+
+trailing_chars_regex = re.compile(r"^[\s|:\-_~)\]., }>]+")
+leading_chars_regex = re.compile(r"[\s|:_(\[{<., ]+$")
+
+def infer_tracks_from_text(text: str) -> typing.List[Track]:
+    """
+    Try to infer a tracklist from a non-formatted text.
+    It assumes the timestamps are in [hh]:mm:ss format and come always in the same order.
+    The track name is everything between timestamps, cleaned up.
+
+    :param text: The text to parse.
+
+    :return: A list of tracks.
+    """
+
+    # find the first line that contains a timestamp (left, timestamp, right)
+    lines: typing.List[typing.Union[str, typing.List[str]]] = text.splitlines()
+    timestamps = [timestamp_regex.findall(line) for line in lines]
+
+    # if a line contains more than 3 timestamps, it's probably a list of timestamps + track name
+    # so we cut, looking at which side the timestamps are
+    for i in range(len(timestamps)):
+        if 3 < len(timestamps[i]):
+            timestamps = timestamps[i]
+            line = lines[i]
+            timestamps_positions = [line.find(timestamp) for timestamp in timestamps]
+
+            # check which side the timestamps are, the side with the least chars is the track name
+            first_timestamp = timestamps_positions[0]
+            last_timestamp = timestamps_positions[-1]
+            side = len(line[:first_timestamp].strip()) < len(line[last_timestamp + len(timestamps[-1]):].strip())
+
+            # cut the line (side == 0 is left, side == 1 is right)
+            if side:
+                timestamps_positions.append(len(line))
+                timestamp_lines = [line[a:b] for a, b in zip(timestamps_positions, timestamps_positions[1:])]
+            else:
+                timestamps_positions.insert(0, 0)
+                timestamp_lines = [line[a:b] for a, b in zip(timestamps_positions, timestamps_positions[1:])]
+
+            lines[i] = timestamp_lines
+        else:
+            lines[i] = [lines[i]]
+
+    # flatten the list
+    lines = [line for sublist in lines for line in sublist]
+
+    timestamp_lines = [timestamp_regex_text.search(line) for line in lines]
+    timestamp_lines = [line.groups() for line in timestamp_lines if line is not None]
+
+    # choose the right side to get the track name
+    tracks_infos = [
+        (right if len(left) < len(right) else left, timestamp) for left, timestamp, right in timestamp_lines
+    ]
+
+    # clean up the track name (remove additional timestamps, trailing and leading chars)
+    tracks_infos = [
+        (trailing_chars_regex.sub("", leading_chars_regex.sub("", timestamp_regex.sub("", track_name))), timestamp)
+        for track_name, timestamp in tracks_infos
+    ]
+
+    # TODO: throw an error if name is empty ?
+
+    # create tracks
+    tracks = [
+        Track(title=secure_filename_simple(track_name), start_timestamp=parse_time_string(timestamp))
+        for track_name, timestamp in tracks_infos
+    ]
+
+    return tracks

--- a/album_splitter/split_file.py
+++ b/album_splitter/split_file.py
@@ -6,7 +6,6 @@ import ffmpy
 
 from .parse_tracks import Track
 
-
 def split_file(
     input_file: Path, tracks: List[Track], destination: Path, output_format: str
 ):
@@ -24,8 +23,7 @@ def split_file(
             file_duration if i == len(tracks) - 1 else tracks[i + 1].start_timestamp
         )
         outputs[
-            destination
-            / (f"{str(i+1).zfill(max_zero_padding)} {track.title}.{output_format}")
+            destination / f"{str(i+1).zfill(max_zero_padding)} {track.title}.{output_format}"
         ] = f"-vn -c copy -ss {start_timestamp} -to {end_timestamp}"
     split_command = ffmpy.FFmpeg(
         inputs={str(input_file): "-y -hide_banner -loglevel error -stats"},

--- a/album_splitter/utils/secure_filename.py
+++ b/album_splitter/utils/secure_filename.py
@@ -4,7 +4,7 @@ import unicodedata
 
 
 # Taken and adapted from https://github.com/pallets/werkzeug/blob/e6c908f36c68eff4ecc10c405d8c2512f27e65a0/src/werkzeug/utils.py#L432
-def secure_filename(filename: str) -> str:
+def secure_filename(filename: str, ascii_only: bool = False) -> str:
     r"""Pass it a filename and it will return a secure version of it. This
     filename can then safely be stored on a regular file system and passed
     to :func:`os.path.join`.  The filename returned is an ASCII only string
@@ -51,5 +51,43 @@ def secure_filename(filename: str) -> str:
         and filename.split(".")[0].upper() in _windows_device_files
     ):
         filename = f"_{filename}"
+
+    return filename
+
+
+def secure_filename_simple(filename: str) -> str:
+    """
+    This function is a simplified version of the secure_filename function above.
+    The only difference is that it doesn't remove non-ascii characters,
+    as removing them makes the filename from other languages completely unusable.
+    Unicode support has come far enough that it's not really necessary to remove them.
+    """
+
+    for sep in os.path.sep, os.path.altsep:
+        if sep:
+            filename = filename.replace(sep, " ")
+
+    _windows_device_files = (
+        "CON",
+        "AUX",
+        "COM1",
+        "COM2",
+        "COM3",
+        "COM4",
+        "LPT1",
+        "LPT2",
+        "LPT3",
+        "PRN",
+        "NUL",
+    )
+    if (
+        os.name == "nt"
+        and filename
+        and filename.split(".")[0].upper() in _windows_device_files
+    ):
+        filename = f"_{filename}"
+
+    # if the filename happens to start with a dash, remove it to avoid confusion with command line arguments
+    filename = filename.lstrip("-")
 
     return filename

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,4 +41,4 @@ Tracker = "https://github.com/crisbal/album-splitter/issues"
 test = ["pytest"]
 
 [project.scripts]
-album-splitter = "album_splitter.__main__:main"
+album-splitter = "album_splitter.__main__:main_entry"


### PR DESCRIPTION
This feature has been tested on a huge playlist of dozens of hours-long videos, alongside multiple standalone hours-long videos, and seems to work well.

The command line I used was:
`python -m album_splitter -yt ... -et -em --format mp3`