### PR TITLE
feat: artwork tag option

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ These songs are already mp3-tagged with their track name and track number, but n
 + I set the tracklist in `tracks.txt` (same tracks as before)
 + I execute `python -m album_splitter --file DogsEatingDogsAlbum.mp3 --album "Dogs Eating Gods" --artist "blink-182" --folder "2012 - Dogs Eating Dogs"`
 + The software will execute, it will split the album, and mp3-tag each track with the author and the album name I passed as a parameter (as well as track number and name). It will also put the files in the folder passed as an argument (instead of putting them in the default `./splits` folder)
++ To add an image you have saved locally as album artwork to the tracks, add the option `--artwork "./path/to/artwork.jpeg"`.
 
 ## Supported formats for the track list (`tracks.txt`)
 

--- a/album_splitter/__main__.py
+++ b/album_splitter/__main__.py
@@ -64,6 +64,11 @@ def get_parser():
         default=None,
     )
     tracks_metadata_group.add_argument(
+        "--artwork",
+        help="Path to an image that will be used as the album artwork. (default: %(default)s)",
+        default=None,
+    )
+    tracks_metadata_group.add_argument(
         "-md",
         "--metadata",
         dest="extra_metadata",
@@ -143,6 +148,7 @@ def main():
             "artist": args.artist,
             "album": args.album,
             "year": args.year,
+            "artwork": args.artwork,
         }
     )
     for tag_data_line in args.extra_metadata or []:

--- a/album_splitter/tag_file.py
+++ b/album_splitter/tag_file.py
@@ -10,7 +10,17 @@ def tag_file(file: Path, tag_data: Dict[str, str]):
         raise RuntimeError(
             f"Something went wrong when loading file for tagging: {file}"
         )
+
     for tag, data in tag_data.items():
+        if tag in ["artwork"] and isinstance(data, str):
+            if Path(data).exists():
+                with open(data, "rb") as img_in:
+                    data = img_in.read()
+            else:
+                print(f"Warning: no artwork file found at {data}, skipping.")
+                continue
+
         if data:
             audio[tag] = data
+
     audio.save()


### PR DESCRIPTION
I added basic support for an `--artwork` option that you can use to specify a path to an image that will be read and added as the `artwork` audio tag for the output tracks.