### PR TITLE
add support for tracks.json

### DIFF
--- a/album_splitter/__main__.py
+++ b/album_splitter/__main__.py
@@ -1,3 +1,4 @@
+import json
 import argparse
 import datetime
 from pathlib import Path
@@ -5,7 +6,7 @@ from urllib.parse import parse_qs, urlparse
 
 from yt_dlp import YoutubeDL
 
-from .parse_tracks import parse_tracks
+from .parse_tracks import parse_tracks_txt, parse_tracks_json
 from .split_file import split_file
 from .tag_file import tag_file
 from .utils.secure_filename import secure_filename
@@ -130,8 +131,19 @@ def main():
     if not tracks_file.exists():
         print(f"Can't find tracks file: {tracks_file}")
         exit(-1)
-    tracks_content = tracks_file.read_text(encoding="utf-8", errors="ignore")
-    tracks = parse_tracks(tracks_content, duration=args.duration)
+    if tracks_file.extension == ".json":
+        with open(tracks_file, "r") as f:
+            tracks = parse_tracks_json(json.load(f), duration=args.duration)
+    elif tracks_file.extension == ".txt":
+        tracks_content = tracks_file.read_text(
+            encoding="utf-8", errors="ignore"
+        )
+        tracks = parse_tracks_txt(tracks_content, duration=args.duration)
+    else:
+        print(
+            f"Unsupported tracks file format: {tracks_file.extension}. Supported formats: .json, .txt"
+        )
+        exit(-1)
     if not len(tracks):
         print("No tracks could be read/parsed from the tracks file.")
         exit(-1)

--- a/album_splitter/parse_tracks.py
+++ b/album_splitter/parse_tracks.py
@@ -18,24 +18,6 @@ def parse_time_string(time: str):
     return seconds
 
 
-def parse_tracks(tracks_content: str, duration: bool = False) -> typing.List[Track]:
-    lines = tracks_content.splitlines()
-    tracks: typing.List[Track] = []
-    current_time = 0
-    for line in lines:
-        line = line.strip()
-        if line.startswith("#") or len(line) == 0:
-            continue
-        track_time, title = parse_line(line)
-        track_time_seconds = parse_time_string(track_time)
-        if not duration:
-            current_time = track_time_seconds
-        tracks.append(Track(title=title, start_timestamp=current_time))
-        if duration:
-            current_time += track_time_seconds
-    return tracks
-
-
 def parse_line(line: str) -> typing.Tuple[str, str]:
     line = line.strip()
     # match [HHH:]MM:SS
@@ -56,3 +38,40 @@ def parse_line(line: str) -> typing.Tuple[str, str]:
         )
     title = title.strip(" -|")
     return timestamp, title
+
+
+def parse_tracks_txt(
+    tracks_content: str, duration: bool = False
+) -> typing.List[Track]:
+    lines = tracks_content.splitlines()
+    tracks: typing.List[Track] = []
+    current_time = 0
+    for line in lines:
+        line = line.strip()
+        if line.startswith("#") or len(line) == 0:
+            continue
+        track_time, title = parse_line(line)
+        track_time_seconds = parse_time_string(track_time)
+        if not duration:
+            current_time = track_time_seconds
+        tracks.append(Track(title=title, start_timestamp=current_time))
+        if duration:
+            current_time += track_time_seconds
+    return tracks
+
+
+def parse_tracks_json(
+    tracks_content: dict, duration: bool = False
+) -> typing.List[Track]:
+    tracks: typing.List[Track] = []
+    current_time = 0
+    for track in tracks_content:
+        title = track["title"]
+        track_time = track["start_time"]
+        track_time_seconds = parse_time_string(track_time)
+        if not duration:
+            current_time = track_time_seconds
+        tracks.append(Track(title=title, start_timestamp=current_time))
+        if duration:
+            current_time += track_time_seconds
+    return tracks


### PR DESCRIPTION
I encountered an encoding issue when providing a tracklist with Japanese characters. I worked around this by adding support for providing a json file with tracks.

This code automatically detects if a `tracks.json` output file is manually supplied by the user, and if so, takes the title & timestamps from this json object.

Right now, the json object should have one attribute, `tracks`, which maps to a list of dicts with `title` and `start_time`. Maybe it could just be the list itself, the `tracks` wrapping is not really necessary...

Todo: add documentation in the readme.